### PR TITLE
drivers: ieee802154: add ed_scan

### DIFF
--- a/drivers/ieee802154/ieee802154_b9x.c
+++ b/drivers/ieee802154/ieee802154_b9x.c
@@ -944,6 +944,14 @@ static void b9x_csl_rx_work(struct k_work *item)
 
 #endif /* CONFIG_OPENTHREAD_CSL_RECEIVER */
 
+/* Work handler for deferred energy scan done callback */
+static void b9x_ed_work_handler(struct k_work *work)
+{
+	struct b9x_data *b9x = CONTAINER_OF(work, struct b9x_data, ed_work);
+
+	b9x->ed_done_cb(b9x->ed_dev, b9x->ed_rssi);
+}
+
 /* Driver initialization */
 static int b9x_init(const struct device *dev)
 {
@@ -979,6 +987,8 @@ static int b9x_init(const struct device *dev)
 	b9x->csl_rx_duration_us = 0;
 	b9x->csl_rx_channel = B9X_TX_CH_NOT_SET;
 #endif /* CONFIG_OPENTHREAD_CSL_RECEIVER */
+	k_work_init(&b9x->ed_work, b9x_ed_work_handler);
+	b9x->ed_done_cb = NULL;
 	return 0;
 }
 
@@ -1002,7 +1012,8 @@ static enum ieee802154_hw_caps b9x_get_capabilities(const struct device *dev)
 	ARG_UNUSED(dev);
 	enum ieee802154_hw_caps caps = IEEE802154_HW_FCS |
 		IEEE802154_HW_FILTER |
-		IEEE802154_HW_TX_RX_ACK;
+		IEEE802154_HW_TX_RX_ACK |
+		IEEE802154_HW_ENERGY_SCAN;
 
 #if defined(CONFIG_NET_PKT_TIMESTAMP) && defined(CONFIG_NET_PKT_TXTIME)
 	caps |= IEEE802154_HW_TXTIME;
@@ -1374,13 +1385,47 @@ static int b9x_tx(const struct device *dev, enum ieee802154_tx_mode mode, struct
 static int b9x_ed_scan(const struct device *dev, uint16_t duration,
 		       energy_scan_done_cb_t done_cb)
 {
-	ARG_UNUSED(dev);
-	ARG_UNUSED(duration);
-	ARG_UNUSED(done_cb);
+	struct b9x_data *b9x = dev->data;
+	int16_t rssi, rssi_max = INT16_MIN;
+	unsigned int t_start;
+	uint32_t scan_time_us;
 
-	/* ed_scan not supported */
+	if (!done_cb) {
+		return -EINVAL;
+	}
 
-	return -ENOTSUP;
+	/* duration is in ms (from OpenThread).
+	 * Clamp to a reasonable range: at least ~1 ms, at most 1 second.
+	 */
+	scan_time_us = (uint32_t)duration * 1000;
+	if (scan_time_us < 1000) {
+		scan_time_us = 1000;
+	}
+	if (scan_time_us > 1000000) {
+		scan_time_us = 1000000;
+	}
+
+	rf_set_rxmode();
+	delay_us(85);
+
+	t_start = stimer_get_tick();
+	do {
+		rssi = (int16_t)rf_get_rssi();
+		if (rssi > rssi_max) {
+			rssi_max = rssi;
+		}
+	} while (!clock_time_exceed(t_start, scan_time_us));
+
+	b9x->ed_rssi = rssi_max;
+	b9x->ed_dev = dev;
+	b9x->ed_done_cb = done_cb;
+
+	/* Defer callback to system workqueue to avoid reentrancy deadlock
+	 * with radio.c's platformRadioProcess event loop.
+	 */
+	k_work_submit(&b9x->ed_work);
+
+	return 0;
 }
 
 /* API implementation: configure */

--- a/drivers/ieee802154/ieee802154_b9x.h
+++ b/drivers/ieee802154/ieee802154_b9x.h
@@ -112,6 +112,10 @@ struct b9x_data {
 	atomic_t current_pm_lock;
 #endif /* CONFIG_PM_DEVICE */
 	ieee802154_event_cb_t event_handler;
+	struct k_work ed_work;
+	energy_scan_done_cb_t ed_done_cb;
+	const struct device *ed_dev;
+	int16_t ed_rssi;
 #if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 	struct b9x_enh_ack_table *enh_ack_table;
 	struct b9x_mac_keys *mac_keys;

--- a/drivers/ieee802154/ieee802154_tlx.c
+++ b/drivers/ieee802154/ieee802154_tlx.c
@@ -977,6 +977,14 @@ static void tlx_csl_rx_work(struct k_work *item)
 
 #endif /* CONFIG_OPENTHREAD_CSL_RECEIVER */
 
+/* Work handler for deferred energy scan done callback */
+static void tlx_ed_work_handler(struct k_work *work)
+{
+	struct tlx_data *tlx = CONTAINER_OF(work, struct tlx_data, ed_work);
+
+	tlx->ed_done_cb(tlx->ed_dev, tlx->ed_rssi);
+}
+
 /* Driver initialization */
 static int tlx_init(const struct device *dev)
 {
@@ -1013,6 +1021,8 @@ static int tlx_init(const struct device *dev)
 	tlx->csl_rx_duration_us = 0;
 	tlx->csl_rx_channel = TLX_TX_CH_NOT_SET;
 #endif /* CONFIG_OPENTHREAD_CSL_RECEIVER */
+	k_work_init(&tlx->ed_work, tlx_ed_work_handler);
+	tlx->ed_done_cb = NULL;
 	return 0;
 }
 
@@ -1036,7 +1046,8 @@ static enum ieee802154_hw_caps tlx_get_capabilities(const struct device *dev)
 	ARG_UNUSED(dev);
 	enum ieee802154_hw_caps caps = IEEE802154_HW_FCS |
 		IEEE802154_HW_FILTER |
-		IEEE802154_HW_TX_RX_ACK;
+		IEEE802154_HW_TX_RX_ACK |
+		IEEE802154_HW_ENERGY_SCAN;
 
 #if defined(CONFIG_NET_PKT_TIMESTAMP) && defined(CONFIG_NET_PKT_TXTIME)
 	caps |= IEEE802154_HW_TXTIME;
@@ -1446,13 +1457,47 @@ static int tlx_tx(const struct device *dev, enum ieee802154_tx_mode mode, struct
 static int tlx_ed_scan(const struct device *dev, uint16_t duration,
 		       energy_scan_done_cb_t done_cb)
 {
-	ARG_UNUSED(dev);
-	ARG_UNUSED(duration);
-	ARG_UNUSED(done_cb);
+	struct tlx_data *tlx = dev->data;
+	int16_t rssi, rssi_max = INT16_MIN;
+	unsigned int t_start;
+	uint32_t scan_time_us;
 
-	/* ed_scan not supported */
+	if (!done_cb) {
+		return -EINVAL;
+	}
 
-	return -ENOTSUP;
+	/* duration is in ms (from OpenThread).
+	 * Clamp to a reasonable range: at least ~1 ms, at most 1 second.
+	 */
+	scan_time_us = (uint32_t)duration * 1000;
+	if (scan_time_us < 1000) {
+		scan_time_us = 1000;
+	}
+	if (scan_time_us > 1000000) {
+		scan_time_us = 1000000;
+	}
+
+	rf_set_rxmode();
+	delay_us(85);
+
+	t_start = stimer_get_tick();
+	do {
+		rssi = (int16_t)rf_get_rssi();
+		if (rssi > rssi_max) {
+			rssi_max = rssi;
+		}
+	} while (!clock_time_exceed(t_start, scan_time_us));
+
+	tlx->ed_rssi = rssi_max;
+	tlx->ed_dev = dev;
+	tlx->ed_done_cb = done_cb;
+
+	/* Defer callback to system workqueue to avoid reentrancy deadlock
+	 * with radio.c's platformRadioProcess event loop.
+	 */
+	k_work_submit(&tlx->ed_work);
+
+	return 0;
 }
 
 /* API implementation: configure */

--- a/drivers/ieee802154/ieee802154_tlx.h
+++ b/drivers/ieee802154/ieee802154_tlx.h
@@ -118,6 +118,11 @@ struct tlx_data {
 	atomic_t current_pm_lock;
 #endif /* CONFIG_PM_DEVICE */
 	ieee802154_event_cb_t event_handler;
+	/* Deferred energy scan done callback (avoids reentrancy deadlock) */
+	struct k_work ed_work;
+	energy_scan_done_cb_t ed_done_cb;
+	const struct device *ed_dev;
+	int16_t ed_rssi;
 #if !defined(CONFIG_OPENTHREAD_THREAD_VERSION_1_1)
 	struct tlx_enh_ack_table *enh_ack_table;
 	struct tlx_mac_keys *mac_keys;

--- a/submanifests/telink.yaml
+++ b/submanifests/telink.yaml
@@ -10,7 +10,7 @@ manifest:
 
     - name: openthread_telink_lib
       url: https://github.com/telink-semi/openthread_telink_lib
-      revision: tags/v4.1.1
+      revision: tags/v4.1.2
       path: modules/lib/openthread_telink_lib
 
     - name: nfc_st25dv


### PR DESCRIPTION
- Enable IEEE802154_HW_ENERGY_SCAN.
- Implement the ed_scan interface: continuously read the RSSI value within the specified duration and record the maximum.
- Invoke done_cb asynchronously in ed_scan.