### PR TITLE
west: update manifests, docs and CI for the tl_ repository renames

### DIFF
--- a/.github/workflows/telink-b91-build.yaml
+++ b/.github/workflows/telink-b91-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-b91-nds-build.yaml
+++ b/.github/workflows/telink-b91-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-b92-build.yaml
+++ b/.github/workflows/telink-b92-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-b92-nds-build.yaml
+++ b/.github/workflows/telink-b92-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-ot-lib.yaml
+++ b/.github/workflows/telink-ot-lib.yaml
@@ -53,6 +53,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-tl321x-build.yaml
+++ b/.github/workflows/telink-tl321x-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-tl321x-nds-build.yaml
+++ b/.github/workflows/telink-tl321x-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-tl721x-build.yaml
+++ b/.github/workflows/telink-tl721x-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-tl721x-nds-build.yaml
+++ b/.github/workflows/telink-tl721x-nds-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-w91-build.yaml
+++ b/.github/workflows/telink-w91-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-w91-nds-build.yaml
+++ b/.github/workflows/telink-w91-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/README.rst
+++ b/README.rst
@@ -39,42 +39,25 @@ and the documentation's `Getting Started Guide`_ to start developing.
 Telink Maintained Repositories
 ******************************
 
-Besides this repository, the SDK pulls in the following Telink maintained
-modules through its west manifests (``west.yml`` and
-``submanifests/telink.yaml``). They carry Telink specific modifications and
-optimizations on top of their upstream projects, or are Telink provided
-components, and are therefore published under the ``tl_`` naming convention:
+Besides this repository (``tl_zephyr``), the SDK pulls in the following Telink
+maintained modules through its west manifests (``west.yml`` and
+``submanifests/telink.yaml``). Forked repositories carry Telink-specific
+modifications and optimizations on top of upstream projects; others are Telink
+provided components. All forked modules are published under the ``tl_`` prefix
+to distinguish them from their upstreams:
 
-.. list-table::
-   :header-rows: 1
+- `tl_mcuboot`_ — fork of `MCUboot`_ with Telink boot-time optimizations
+- `tl_openthread`_ — fork of `OpenThread`_ with Telink security and performance patches
+- `tl_xz`_ — fork of `XZ Utils`_ integrated as a Zephyr module
+- `tl_openthread_libs`_ — Telink-provided prebuilt OpenThread FTD libraries
+- `hal_telink`_ — Telink HAL module (follows the upstream ``hal_<vendor>`` naming convention)
 
-   * - Repository
-     - Upstream
-     - Telink Modifications
-   * - `tl_mcuboot`_
-     - `MCUboot`_
-     - Boot time optimizations: the primary slot image is validated only on the first boot (``BOOT_VALIDATE_SLOT0_ONCE``); on TL323X the application image hash is computed directly from flash storage (``CONFIG_BOOT_IMG_HASH_DIRECTLY_ON_STORAGE``) without a RAM copy.
-   * - `tl_openthread`_
-     - `OpenThread`_
-     - Security fix for a MAC Key ID Mode 2 frame injection issue, and performance optimization placing the sleepy end device (SED) processing call tree (tasklets, timers, MAC frame handling, mesh forwarding) in the RAM code section (``OT_SED_RAM``) for faster execution on Telink SoCs.
-   * - `tl_xz`_
-     - `XZ Utils`_
-     - Zephyr module integration for ``liblzma`` (a ``zephyr/`` CMake and Kconfig wrapper) with size optimization (``-Os``) enabled by default.
-   * - `tl_openthread_libs`_
-     - Telink owned
-     - Prebuilt OpenThread FTD libraries for Telink SoCs, in extended and reduced feature set variants, linked as a Zephyr module when ``CONFIG_OPENTHREAD_TELINK_LIBRARY`` is selected.
+For details on each module, see the linked repositories.
 
-The Telink HAL module `hal_telink`_ keeps the upstream Zephyr HAL naming
-convention (``hal_<vendor>``). Other Telink provided components, such as the
-BLE SDK (``tl_ble_sdk_zephyr``), ``tflite-micro-telink`` and the NFC driver
-``nfc_st25dv``, keep their component oriented names and are referenced
-unchanged; all remaining manifest projects are consumed as-is from their
-upstream repositories.
-
-This repository and the modules listed above were previously published under
-their upstream-derived names (``zephyr``, ``mcuboot``, ``openthread``, ``xz``
-and ``openthread_telink_lib``) and have been renamed to carry the ``tl_``
-prefix, making the Telink maintained components of the SDK easy to identify.
+The modules above were previously published under their upstream-derived names
+(``zephyr``, ``mcuboot``, ``openthread``, ``xz`` and ``openthread_telink_lib``)
+and have been renamed with the ``tl_`` prefix to make the Telink maintained
+components of the SDK easy to identify.
 
 .. _tl_mcuboot: https://github.com/telink-semi/tl_mcuboot
 .. _MCUboot: https://github.com/mcu-tools/mcuboot

--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,55 @@ Getting Started
 Welcome to Zephyr! See the `Introduction to Zephyr`_ for a high-level overview,
 and the documentation's `Getting Started Guide`_ to start developing.
 
+Telink Maintained Repositories
+******************************
+
+Besides this repository, the SDK pulls in the following Telink maintained
+modules through its west manifests (``west.yml`` and
+``submanifests/telink.yaml``). They carry Telink specific modifications and
+optimizations on top of their upstream projects, or are Telink provided
+components, and are therefore published under the ``tl_`` naming convention:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Repository
+     - Upstream
+     - Telink Modifications
+   * - `tl_mcuboot`_
+     - `MCUboot`_
+     - Boot time optimizations: the primary slot image is validated only on the first boot (``BOOT_VALIDATE_SLOT0_ONCE``); on TL323X the application image hash is computed directly from flash storage (``CONFIG_BOOT_IMG_HASH_DIRECTLY_ON_STORAGE``) without a RAM copy.
+   * - `tl_openthread`_
+     - `OpenThread`_
+     - Security fix for a MAC Key ID Mode 2 frame injection issue, and performance optimization placing the sleepy end device (SED) processing call tree (tasklets, timers, MAC frame handling, mesh forwarding) in the RAM code section (``OT_SED_RAM``) for faster execution on Telink SoCs.
+   * - `tl_xz`_
+     - `XZ Utils`_
+     - Zephyr module integration for ``liblzma`` (a ``zephyr/`` CMake and Kconfig wrapper) with size optimization (``-Os``) enabled by default.
+   * - `tl_openthread_libs`_
+     - Telink owned
+     - Prebuilt OpenThread FTD libraries for Telink SoCs, in extended and reduced feature set variants, linked as a Zephyr module when ``CONFIG_OPENTHREAD_TELINK_LIBRARY`` is selected.
+
+The Telink HAL module `hal_telink`_ keeps the upstream Zephyr HAL naming
+convention (``hal_<vendor>``). Other Telink provided components, such as the
+BLE SDK (``tl_ble_sdk_zephyr``), ``tflite-micro-telink`` and the NFC driver
+``nfc_st25dv``, keep their component oriented names and are referenced
+unchanged; all remaining manifest projects are consumed as-is from their
+upstream repositories.
+
+This repository and the modules listed above were previously published under
+their upstream-derived names (``zephyr``, ``mcuboot``, ``openthread``, ``xz``
+and ``openthread_telink_lib``) and have been renamed to carry the ``tl_``
+prefix, making the Telink maintained components of the SDK easy to identify.
+
+.. _tl_mcuboot: https://github.com/telink-semi/tl_mcuboot
+.. _MCUboot: https://github.com/mcu-tools/mcuboot
+.. _tl_openthread: https://github.com/telink-semi/tl_openthread
+.. _OpenThread: https://github.com/openthread/openthread
+.. _tl_xz: https://github.com/telink-semi/tl_xz
+.. _XZ Utils: https://github.com/tukaani-project/xz
+.. _tl_openthread_libs: https://github.com/telink-semi/tl_openthread_libs
+.. _hal_telink: https://github.com/telink-semi/hal_telink
+
 .. start_include_here
 
 Community Support

--- a/README.rst
+++ b/README.rst
@@ -46,8 +46,6 @@ modifications and optimizations on top of upstream projects; others are Telink
 provided components. All forked modules are published under the ``tl_`` prefix
 to distinguish them from their upstreams:
 
-- `tl_mcuboot`_ — fork of `MCUboot`_ with Telink boot-time optimizations
-- `tl_openthread`_ — fork of `OpenThread`_ with Telink security and performance patches
 - `tl_xz`_ — fork of `XZ Utils`_ integrated as a Zephyr module
 - `tl_openthread_libs`_ — Telink-provided prebuilt OpenThread FTD libraries
 - `hal_telink`_ — Telink HAL module (follows the upstream ``hal_<vendor>`` naming convention)
@@ -55,14 +53,10 @@ to distinguish them from their upstreams:
 For details on each module, see the linked repositories.
 
 The modules above were previously published under their upstream-derived names
-(``zephyr``, ``mcuboot``, ``openthread``, ``xz`` and ``openthread_telink_lib``)
+(``zephyr``, ``xz`` and ``openthread_telink_lib``)
 and have been renamed with the ``tl_`` prefix to make the Telink maintained
 components of the SDK easy to identify.
 
-.. _tl_mcuboot: https://github.com/telink-semi/tl_mcuboot
-.. _MCUboot: https://github.com/mcu-tools/mcuboot
-.. _tl_openthread: https://github.com/telink-semi/tl_openthread
-.. _OpenThread: https://github.com/openthread/openthread
 .. _tl_xz: https://github.com/telink-semi/tl_xz
 .. _XZ Utils: https://github.com/tukaani-project/xz
 .. _tl_openthread_libs: https://github.com/telink-semi/tl_openthread_libs

--- a/samples/net/openthread/lib_builder/README.rst
+++ b/samples/net/openthread/lib_builder/README.rst
@@ -2,7 +2,7 @@ Telink openthread library builder
 #################################
 This is a project to create Telink openthread prebuilt libraries.
 This project is used by github CI, see `openthread_telink_lib <../../../../.github/workflows/telink-ot-lib.yaml>`_ for details.
-This job is creating Telink openthread libraries set as its artifacts, which are usually populated in `official Telink openthread libraries repository <https://github.com/telink-semi/openthread_telink_lib>`_.
+This job is creating Telink openthread libraries set as its artifacts, which are usually populated in `official Telink openthread libraries repository <https://github.com/telink-semi/tl_openthread_libs>`_.
 
 
 CI libraries generating
@@ -52,7 +52,7 @@ Building details
 Link application against prebuilt library
 *****************************************
 To link application against prebuilt library provide variable *OVERLAY_CONFIG* with corresponding library type.
-See *configs/* directory under `openthread_telink_lib module <https://github.com/telink-semi/openthread_telink_lib>`_ for available configurations.
+See *configs/* directory under `openthread_telink_lib module <https://github.com/telink-semi/tl_openthread_libs>`_ for available configurations.
 
 As example building *openthread-cli*:
 

--- a/submanifests/telink.yaml
+++ b/submanifests/telink.yaml
@@ -4,12 +4,12 @@
 manifest:
   projects:
     - name: lzma
-      url: https://github.com/telink-semi/xz
+      url: https://github.com/telink-semi/tl_xz
       revision: 053c1629f452b43339e7cd5c66fc89a143f4827a
       path: modules/lib/lzma
 
     - name: openthread_telink_lib
-      url: https://github.com/telink-semi/openthread_telink_lib
+      url: https://github.com/telink-semi/tl_openthread_libs
       revision: tags/v4.1.2
       path: modules/lib/openthread_telink_lib
 


### PR DESCRIPTION
## Summary

Update repository references for the `tl_` repo rename, phase 1 (UTCSH-526 / Rename-01, parent epic UTCSH-525).

| Old | New |
|---|---|
| `telink-semi/zephyr` | `telink-semi/tl_zephyr` |
| `telink-semi/mcuboot` | `telink-semi/tl_mcuboot` |
| `telink-semi/openthread` | `telink-semi/tl_openthread` |
| `telink-semi/xz` | `telink-semi/tl_xz` |
| `telink-semi/openthread_telink_lib` | `telink-semi/tl_openthread_libs` (placeholder first) |


Notes:
- `openthread_telink_lib` uses a placeholder-first strategy: `tl_openthread_libs` is published as a mirror snapshot **before** this PR merges, so the new URL is live immediately; the original repository is renamed onto that name after ThreadGroup confirmation (UTCSH-533 / Rename-08). The west project `name` and local `path` (`modules/lib/openthread_telink_lib`) stay unchanged — only the manifest `url` changes.
- Historical release notes are left unchanged (GitHub 301 redirects cover them).
- the develop manifests (`west.yml` + `submanifests/telink.yaml`) actually pull in **`tl_xz`** and **`tl_openthread_libs`** only;
`tl_mcuboot` and `tl_openthread` are consumed by other SDK branches.

## Changes

### west manifests & docs URLs (04a48749ba0)
- `submanifests/telink.yaml`: project URLs now point to the renamed repositories - `openthread_telink_lib` references now point to `tl_openthread_libs`, published   first as a placeholder mirror; the original repository is renamed onto that   name after ThreadGroup confirmation;
- `samples/net/openthread/lib_builder/README.rst` URLs updated;
- Historical release notes left unchanged — GitHub 301 redirects cover them;

### CI (69916089f9d)
After the rename, `actions/checkout` checks out into `tl_zephyr/` instead of `zephyr/`, which broke `west init -l zephyr` in every Telink workflow: FATAL ERROR: can't init: no west.yml found in /home/runner/work/tl_zephyr/zephyr

- All Telink workflows now create a `zephyr` symlink pointing to the `tl_zephyr` checkout directory before running `west init`

### README (58e67bcdd1c, 67fd92d58e1)
- New "Telink Maintained Repositories" section: concise list of Telink maintained forks with links to both the Telink repo and its upstream
- Lists only the repositories this branch actually pulls in (`tl_xz`,  `tl_openthread_libs`) so the README matches the manifests
- No Kconfig symbols referenced (avoids UndefinedKconfig compliance failures); detailed feature documentation lives in the individual module repositories

## Merge timing

> [!WARNING]
> Do NOT merge before the freeze window. CI cloning `tl_*.git` URLs fails until the GitHub-side renames are executed (UTCSH-527 / Rename-02, UTCSH-528 / Rename-03). Exception: `tl_openthread_libs` is already live as a placeholder mirror, so that URL works before the freeze window.

## Verification

- [x] CI green on this PR: all Telink build workflows (TL321x / TL521x / TL721x / W91, incl. NDS variants) and compliance checks pass
- [x] Old URLs keep working via GitHub 301 redirects — daily `git pull` / `push` / `west update` need no local action
- [x] `west update` succeeds with the updated manifest
- [x] `west update` fetches `tl_openthread_libs` (placeholder mirror) via the updated submanifest
- [x] No remaining `telink-semi/{zephyr,mcuboot,openthread,xz,openthread_telink_lib}` references outside release notes

## Notes
- `openthread_telink_lib` is not renamed yet; the placeholder `tl_openthread_libs` serves west in the meantime. The real repo swaps in later with no further action required from developers.