### PR TITLE
west: update telink manifest and doc URLs for tl_ repo rename

### DIFF
--- a/.github/workflows/telink-b91-build.yaml
+++ b/.github/workflows/telink-b91-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         # west blobs fetch hal_telink

--- a/.github/workflows/telink-b91-nds-build.yaml
+++ b/.github/workflows/telink-b91-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         # west blobs fetch hal_telink

--- a/.github/workflows/telink-b92-build.yaml
+++ b/.github/workflows/telink-b92-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         # west blobs fetch hal_telink

--- a/.github/workflows/telink-b92-nds-build.yaml
+++ b/.github/workflows/telink-b92-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         # west blobs fetch hal_telink

--- a/.github/workflows/telink-tl321x-build.yaml
+++ b/.github/workflows/telink-tl321x-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         # west blobs fetch hal_telink

--- a/.github/workflows/telink-tl321x-nds-build.yaml
+++ b/.github/workflows/telink-tl321x-nds-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         # west blobs fetch hal_telink

--- a/.github/workflows/telink-tl322x-build.yaml
+++ b/.github/workflows/telink-tl322x-build.yaml
@@ -34,6 +34,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-tl322x-nds-build.yaml
+++ b/.github/workflows/telink-tl322x-nds-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-tl323x-build.yaml
+++ b/.github/workflows/telink-tl323x-build.yaml
@@ -34,6 +34,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-tl323x-nds-build.yaml
+++ b/.github/workflows/telink-tl323x-nds-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-tl521x-build.yaml
+++ b/.github/workflows/telink-tl521x-build.yaml
@@ -34,6 +34,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-tl521x-nds-build.yaml
+++ b/.github/workflows/telink-tl521x-nds-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-tl721x-build.yaml
+++ b/.github/workflows/telink-tl721x-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-tl721x-nds-build.yaml
+++ b/.github/workflows/telink-tl721x-nds-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west blobs fetch hal_telink

--- a/.github/workflows/telink-w91-build.yaml
+++ b/.github/workflows/telink-w91-build.yaml
@@ -37,6 +37,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/.github/workflows/telink-w91-nds-build.yaml
+++ b/.github/workflows/telink-w91-nds-build.yaml
@@ -35,6 +35,8 @@ jobs:
       run: |
         pip install west
         cd ..
+        # checkout dir is "tl_zephyr", but west and build paths expect "zephyr"
+        ln -sf tl_zephyr zephyr
         west init -l zephyr
         west update
         west zephyr-export

--- a/README.md
+++ b/README.md
@@ -63,24 +63,25 @@ It is designed for developing a wide range of wireless IoT products including sm
 
 ## 🧩 Telink Maintained Repositories
 
-Besides this repository, the SDK pulls in the following Telink maintained
-modules through `submanifests/telink.yaml`. They carry Telink specific
-modifications and optimizations on top of their upstream projects, or are
-Telink provided components, and are therefore published under the `tl_`
-naming convention:
+Besides this repository (`tl_zephyr`), the SDK pulls in the following Telink
+maintained modules through its west manifests (`west.yml` and
+`submanifests/telink.yaml`). Forked repositories carry Telink-specific
+modifications and optimizations on top of upstream projects; others are Telink
+provided components. All forked modules are published under the `tl_` prefix
+to distinguish them from their upstreams:
 
-| Repository | Upstream | Telink Modifications |
-|------------|----------|----------------------|
-| [tl_mcuboot](https://github.com/telink-semi/tl_mcuboot) | [MCUboot](https://github.com/mcu-tools/mcuboot) | Boot time optimizations: the primary slot image is validated only on the first boot (`BOOT_VALIDATE_SLOT0_ONCE`); on TL323X the application image hash is computed directly from flash storage (`CONFIG_BOOT_IMG_HASH_DIRECTLY_ON_STORAGE`) without a RAM copy. |
-| [tl_openthread](https://github.com/telink-semi/tl_openthread) | [OpenThread](https://github.com/openthread/openthread) | Performance optimization: the sleepy end device (SED) processing call tree (tasklets, timers, MAC frame handling, mesh forwarding) is placed in the RAM code section (`OT_SED_RAM`) for faster execution on Telink SoCs. |
-| [tl_xz](https://github.com/telink-semi/tl_xz) | [XZ Utils](https://github.com/tukaani-project/xz) | Zephyr module integration for `liblzma` (a `zephyr/` CMake and Kconfig wrapper) with size optimization (`-Os`) enabled by default. |
-| [tl_openthread_libs](https://github.com/telink-semi/tl_openthread_libs) | Telink owned | Prebuilt OpenThread FTD libraries for Telink SoCs, in extended and reduced feature set variants, linked as a Zephyr module when `CONFIG_OPENTHREAD_TELINK_LIBRARY` is selected. |
+- [tl_mcuboot](https://github.com/telink-semi/tl_mcuboot) — fork of [MCUboot](https://github.com/mcu-tools/mcuboot) with Telink boot-time optimizations
+- [tl_openthread](https://github.com/telink-semi/tl_openthread) — fork of [OpenThread](https://github.com/openthread/openthread) with Telink security and performance patches
+- [tl_xz](https://github.com/telink-semi/tl_xz) — fork of [XZ Utils](https://github.com/tukaani-project/xz) integrated as a Zephyr module
+- [tl_openthread_libs](https://github.com/telink-semi/tl_openthread_libs) — Telink-provided prebuilt OpenThread FTD libraries
+- [hal_telink](https://github.com/telink-semi/hal_telink) — Telink HAL module (follows the upstream `hal_<vendor>` naming convention)
 
-The Telink HAL module [hal_telink](https://github.com/telink-semi/hal_telink) keeps the
-upstream Zephyr HAL naming convention (`hal_<vendor>`) and is fetched through the
-top-level `west.yml`; the NFC driver module `nfc_st25dv` keeps its component name as
-well. All other manifest projects are consumed unchanged from their upstream
-repositories.
+For details on each module, see the linked repositories.
+
+The modules above were previously published under their upstream-derived names
+(`zephyr`, `mcuboot`, `openthread`, `xz` and `openthread_telink_lib`) and have
+been renamed with the `tl_` prefix to make the Telink maintained components of
+the SDK easy to identify.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ It is designed for developing a wide range of wireless IoT products including sm
 
 ---
 
+## 🧩 Telink Maintained Repositories
+
+Besides this repository, the SDK pulls in the following Telink maintained
+modules through `submanifests/telink.yaml`. They carry Telink specific
+modifications and optimizations on top of their upstream projects, or are
+Telink provided components, and are therefore published under the `tl_`
+naming convention:
+
+| Repository | Upstream | Telink Modifications |
+|------------|----------|----------------------|
+| [tl_mcuboot](https://github.com/telink-semi/tl_mcuboot) | [MCUboot](https://github.com/mcu-tools/mcuboot) | Boot time optimizations: the primary slot image is validated only on the first boot (`BOOT_VALIDATE_SLOT0_ONCE`); on TL323X the application image hash is computed directly from flash storage (`CONFIG_BOOT_IMG_HASH_DIRECTLY_ON_STORAGE`) without a RAM copy. |
+| [tl_openthread](https://github.com/telink-semi/tl_openthread) | [OpenThread](https://github.com/openthread/openthread) | Performance optimization: the sleepy end device (SED) processing call tree (tasklets, timers, MAC frame handling, mesh forwarding) is placed in the RAM code section (`OT_SED_RAM`) for faster execution on Telink SoCs. |
+| [tl_xz](https://github.com/telink-semi/tl_xz) | [XZ Utils](https://github.com/tukaani-project/xz) | Zephyr module integration for `liblzma` (a `zephyr/` CMake and Kconfig wrapper) with size optimization (`-Os`) enabled by default. |
+| [tl_openthread_libs](https://github.com/telink-semi/tl_openthread_libs) | Telink owned | Prebuilt OpenThread FTD libraries for Telink SoCs, in extended and reduced feature set variants, linked as a Zephyr module when `CONFIG_OPENTHREAD_TELINK_LIBRARY` is selected. |
+
+The Telink HAL module [hal_telink](https://github.com/telink-semi/hal_telink) keeps the
+upstream Zephyr HAL naming convention (`hal_<vendor>`) and is fetched through the
+top-level `west.yml`; the NFC driver module `nfc_st25dv` keeps its component name as
+well. All other manifest projects are consumed unchanged from their upstream
+repositories.
+
+---
+
 ## 📝 Release Information
 
 For version history and detailed changelog, refer to the [Release Note](tl_zephyr_sdk_Release_Note.md).

--- a/doc/telink/getting_started/index.md
+++ b/doc/telink/getting_started/index.md
@@ -1,6 +1,6 @@
 # Telink Zephyr SDK Getting Started Guide
 
-[![Version](https://img.shields.io/badge/Version-tl_v1.0.1--rc1--v4.1.0-blue?style=flat-square)](https://github.com/telink-semi/zephyr/releases/tag/tl_v1.0.1-rc1-v4.1.0)
+[![Version](https://img.shields.io/badge/Version-tl_v1.0.1--rc1--v4.1.0-blue?style=flat-square)](https://github.com/telink-semi/tl_zephyr/releases/tag/tl_v1.0.1-rc1-v4.1.0)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v4.1.0-green?style=flat-square)](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v4.1.0)
 [![License](https://img.shields.io/badge/License-Apache%202.0-red?style=flat-square)](../../../LICENSE)
 
@@ -55,7 +55,7 @@ Hardware and software requirements to prepare before running the SDK.
 |-|-|
 |Toolchain| RISC-V 64-bit Zephyr SDK Toolchain |
 |Burning Tool | [Telink BDT for Linux](https://doc.telink-semi.cn/tools/bdt/Linux/BDT_Linux.zip) (Burning and Debugging tool) |
-|SDK|[Telink Zephyr SDK](https://github.com/telink-semi/zephyr)  |
+|SDK|[Telink Zephyr SDK](https://github.com/telink-semi/tl_zephyr)  |
 
 
 ## Install Dependencies
@@ -137,7 +137,7 @@ Zephyr's multi-repository meta-tool.
 
 The Telink Zephyr SDK is a fork of the upstream
 [zephyrproject-rtos/zephyr](https://github.com/zephyrproject-rtos/zephyr)
-repository, hosted at [telink-semi/zephyr](https://github.com/telink-semi/zephyr).
+repository, hosted at [telink-semi/tl_zephyr](https://github.com/telink-semi/tl_zephyr).
 The Telink-specific changes live on the `release-v1.0-v4.1-branch` branch.
 
 1. Initialize the west workspace with the upstream manifest (this creates the
@@ -173,7 +173,7 @@ The Telink-specific changes live on the `release-v1.0-v4.1-branch` branch.
 
    ```bash
    cd ~/zephyrproject/zephyr
-   git remote add telink https://github.com/telink-semi/zephyr
+   git remote add telink https://github.com/telink-semi/tl_zephyr
    git fetch telink
    git checkout release-v1.0-v4.1-branch
    cd ..
@@ -958,7 +958,7 @@ Here are some next steps for exploring the Telink Zephyr SDK:
 - Try other [Samples and Demos](https://docs.zephyrproject.org/latest/samples/index.html#samples)
   from the upstream Zephyr documentation.
 - Build Telink Matter applications — see the
-  [Telink Matter SDK README](https://github.com/telink-semi/connectedhomeip)
+  [Telink Matter SDK README](https://github.com/telink-semi/tl_matter)
   and the per-board `*_README.md` build guides.
 - Read the [Telink Zephyr SDK Release Note](../releases/release-notes-tl_v1.0.1.md) for
   the list of supported chips, features and known issues.
@@ -977,7 +977,7 @@ answer there.
 
 - **Telink Matter Developer Guide**: https://doc.telink-semi.cn/doc/en/software/res/sdk/matter/telink_matter_developer_guide_en/
 - **Upstream Zephyr docs**: https://docs.zephyrproject.org/
-- **GitHub (Telink fork)**: https://github.com/telink-semi/zephyr
+- **GitHub (Telink fork)**: https://github.com/telink-semi/tl_zephyr
 
 When asking for help, include:
 

--- a/submanifests/telink.yaml
+++ b/submanifests/telink.yaml
@@ -4,24 +4,24 @@
 manifest:
   projects:
     - name: lzma
-      url: https://github.com/telink-semi/xz
+      url: https://github.com/telink-semi/tl_xz
       revision: 053c1629f452b43339e7cd5c66fc89a143f4827a
       path: modules/lib/lzma
 
     - name: mcuboot
-      url: https://github.com/telink-semi/mcuboot
+      url: https://github.com/telink-semi/tl_mcuboot
       revision: ce0da85c39c749df49b0ec62b33d2ecdea24c927
       path: bootloader/mcuboot
       groups:
         - bootloader
 
     - name: openthread
-      url: https://github.com/telink-semi/openthread
+      url: https://github.com/telink-semi/tl_openthread
       revision: 542aaab44e1308e1a8a24573dfbd413fade342ee
       path: modules/lib/openthread
 
     - name: openthread_telink_lib
-      url: https://github.com/telink-semi/openthread_telink_lib
+      url: https://github.com/telink-semi/tl_openthread_libs
       revision: tags/v4.1.2
       path: modules/lib/openthread_telink_lib
 


### PR DESCRIPTION
## Summary

Update repository references for the `tl_` repo rename, phase 1 (UTCSH-526 / Rename-01, parent epic UTCSH-525).

| Old | New |
|---|---|
| `telink-semi/zephyr` | `telink-semi/tl_zephyr` |
| `telink-semi/mcuboot` | `telink-semi/tl_mcuboot` |
| `telink-semi/openthread` | `telink-semi/tl_openthread` |
| `telink-semi/xz` | `telink-semi/tl_xz` |
| `telink-semi/openthread_telink_lib` | `telink-semi/tl_openthread_libs` (placeholder first) |
| `telink-semi/connectedhomeip` | `telink-semi/tl_matter` (rename executed 2026-08) |

Notes:
- `openthread_telink_lib` uses a placeholder-first strategy: `tl_openthread_libs` is published as a mirror snapshot **before** this PR merges, so the new URL is live immediately; the original repository is renamed onto that name after ThreadGroup confirmation (UTCSH-533 / Rename-08). The west project `name` and local `path` (`modules/lib/openthread_telink_lib`) stay unchanged — only the manifest `url` changes.
- Historical release notes are left unchanged (GitHub 301 redirects cover them).

## Changes

- `west.yml` / `submanifests/*.yaml`: manifest URLs and `repo-path` entries
- `.github/workflows/`: CI clone/fetch URLs
- README / docs: repository links

## Merge timing

> [!WARNING]
> Do NOT merge before the freeze window. CI cloning `tl_*.git` URLs fails until the GitHub-side renames are executed (UTCSH-527 / Rename-02, UTCSH-528 / Rename-03). Exception: `tl_openthread_libs` is already live as a placeholder mirror, so that URL works before the freeze window.

## Verification

- [ ] CI green after the GitHub-side rename is executed
- [ ] `west update` succeeds with the updated manifest
- [ ] `west update` fetches `tl_openthread_libs` (placeholder mirror) via the updated submanifest
- [ ] No remaining `telink-semi/{zephyr,mcuboot,openthread,xz,openthread_telink_lib}` references outside release notes

Tracking: UTCSH-525 (epic) / UTCSH-526 (Rename-01)
