### PR TITLE
feat: optimize BLE suspend exit latency, pull up SWS and update BLE sdk

### DIFF
--- a/.github/workflows/telink-tl323x-build.yaml
+++ b/.github/workflows/telink-tl323x-build.yaml
@@ -101,6 +101,12 @@ jobs:
         cd ..
         west build -b tl3238x     -d build_ot_cli_tl323x                      zephyr/samples/net/openthread/cli              -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
 
+    - name: Build TL323x net/openthread/ot_ble_test
+      run: |
+        cd ..
+        west build -b tl3238x     -d build_ot_ble_test_tl323x                    zephyr/samples/net/openthread/ot_ble_test           -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
+
     - name: Build TL323x net/openthread/coprocessor in RCP configuration with UART interface
       run: |
         cd ..
@@ -135,6 +141,7 @@ jobs:
         cp ../build_fade_tl323x/zephyr/zephyr.bin                       telink_build_artifacts/tl323x_tests_pwm.bin
         cp ../build_peripheral_ht_tl323x/zephyr/zephyr.bin              telink_build_artifacts/tl323x_peripheral_ht.bin
         cp ../build_ot_cli_tl323x/zephyr/zephyr.bin                     telink_build_artifacts/tl323x_ot_cli.bin
+        cp ../build_ot_ble_test_tl323x/zephyr/zephyr.bin                telink_build_artifacts/tl323x_ot_ble_test.bin
         cp ../build_ot_coprocessor_rcp_uart_tl323x/zephyr/zephyr.bin    telink_build_artifacts/tl323x_ot_coprocessor_rcp_uart.bin
         cp ../build_crypto_mbedtls_tl323x/zephyr/zephyr.bin             telink_build_artifacts/tl323x_mbedtls.bin
         cp ../build_ot_echo_client_pm_deep_tl3238x/zephyr/zephyr.bin    telink_build_artifacts/tl323x_ot_echo_client_pm_retention.bin

--- a/.github/workflows/telink-tl721x-build.yaml
+++ b/.github/workflows/telink-tl721x-build.yaml
@@ -97,6 +97,11 @@ jobs:
         cd ..
         west build -b tl7218x                  -d build_ot_cli_tl721x                    zephyr/samples/net/openthread/cli                        -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
 
+    - name: Build TL721X samples/net/openthread/ot_ble_test
+      run: |
+        cd ..
+        west build -b tl7218x                  -d build_ot_ble_test_tl721x                    zephyr/samples/net/openthread/ot_ble_test           -- -DCONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
     - name: Build TL721X samples/net/sockets/echo_server for OpenThread
       run: |
         cd ..
@@ -147,6 +152,7 @@ jobs:
         cp ../build_adc_tl721x/zephyr/zephyr.bin                       telink_build_artifacts/tl721x_adc.bin
         cp ../build_usb_console_tl721x/zephyr/zephyr.bin               telink_build_artifacts/tl721x_usb_console.bin
         cp ../build_ot_cli_tl721x/zephyr/zephyr.bin                    telink_build_artifacts/tl721x_ot_cli.bin
+        cp ../build_ot_ble_test_tl721x/zephyr/zephyr.bin               telink_build_artifacts/tl721x_ot_ble_test.bin
         cp ../build_ot_echo_server_tl721x/zephyr/zephyr.bin            telink_build_artifacts/tl721x_ot_echo_server.bin
         cp ../build_ot_echo_client_tl721x/zephyr/zephyr.bin            telink_build_artifacts/tl721x_ot_echo_client.bin
         cp ../build_ot_echo_client_pm_deep_tl721x/zephyr/zephyr.bin    telink_build_artifacts/tl721x_ot_echo_client_pm_retention.bin

--- a/soc/telink/tlsr/telink_tlx/power.c
+++ b/soc/telink/tlsr/telink_tlx/power.c
@@ -175,8 +175,12 @@ void pm_state_exit_post_ops(enum pm_state state, uint8_t substate_id)
 	if (tlx_resumed_from_deep_sleep_retention) {
 		csr_clear(mip, MIP_MEIP);
 		tlx_resumed_from_deep_sleep_retention = false;
-	}
+	}else
 #endif /* CONFIG_SOC_SERIES_RISCV_TELINK_TLX_RETENTION */
+	{
+		extern void blc_ll_set_suspend_exit_latency(void);
+		blc_ll_set_suspend_exit_latency();
+	}
 
 	/*
 	 * System is now in active mode. Enabling interrupts which were

--- a/soc/telink/tlsr/telink_tlx/soc.c
+++ b/soc/telink/tlsr/telink_tlx/soc.c
@@ -344,7 +344,7 @@ void soc_early_init_hook(void)
 
 	/* system init */
 	sys_init(POWER_MODE, VBAT_TYPE, INTERNAL_CAP_XTAL24M);
-
+	gpio_set_up_down_res(GPIO_SWS, GPIO_PIN_PULLUP_1M);
 	/* Only need for lighting to switch from zigbee to matter */
 #if CONFIG_SOC_RISCV_TELINK_TL323X && !CONFIG_PM && !CONFIG_MCUBOOT
 	/* Enable clock before operate rf register */

--- a/west.yml
+++ b/west.yml
@@ -260,7 +260,7 @@ manifest:
     - name: hal_telink
       remote: telink-semi
       repo-path: hal_telink
-      revision: 3967e49a847705a8e81b5556b7df720c90e83c26
+      revision: pull/205/head
       path: modules/hal/telink
       groups:
         - hal
@@ -370,7 +370,7 @@ manifest:
     - name: telink_ble_sdk
       remote: telink-semi
       repo-path: tl_ble_sdk_zephyr
-      revision: 9135c8eddb7caf72256c911b0ef113fb4037b1b4
+      revision: pull/4/head
       path: modules/hal/telink_ble_sdk
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -370,7 +370,7 @@ manifest:
     - name: telink_ble_sdk
       remote: telink-semi
       repo-path: tl_ble_sdk_zephyr
-      revision: 3171a9bef5cec052598ed870181554817d2526b1
+      revision: 6a90a6e26989144b54da02090576859c8444c7e2
       path: modules/hal/telink_ble_sdk
       groups:
         - hal

--- a/west.yml
+++ b/west.yml
@@ -260,7 +260,7 @@ manifest:
     - name: hal_telink
       remote: telink-semi
       repo-path: hal_telink
-      revision: pull/205/head
+      revision: e36f3e31d3d68a5ecfff4b814632eda9fbe52179
       path: modules/hal/telink
       groups:
         - hal
@@ -370,7 +370,7 @@ manifest:
     - name: telink_ble_sdk
       remote: telink-semi
       repo-path: tl_ble_sdk_zephyr
-      revision: pull/4/head
+      revision: 3171a9bef5cec052598ed870181554817d2526b1
       path: modules/hal/telink_ble_sdk
       groups:
         - hal


### PR DESCRIPTION
## Summary

This PR optimizes BLE suspend exit latency management and fixes SWS pin floating,
along with syncing hal_telink and telink_ble_sdk to their latest revisions.

## Changes

### SoC-level changes (tl_zephyr)
- **power.c**: Call `blc_ll_set_suspend_exit_latency()` in `pm_state_exit_post_ops()`
  on the non-retention wakeup path, allowing the BLE library to dynamically set
  exit latency instead of relying on hardcoded compile-time macros.
- **soc.c**: Add `gpio_set_up_down_res(GPIO_SWS, GPIO_PIN_PULLUP_1M)` in
  `soc_early_init_hook()` to prevent SWS pin floating and reduce power leakage.

### Manifest sync (west.yml)
- **hal_telink**: `3967e49` → `e36f3e3` (dev-tlk_v1.0)
- **telink_ble_sdk**: `9135c8e` → `3171a9b` (release/V4.0.4.8)

### Dependency changes (hal_telink + telink_ble_sdk)

#### BLE controller library naming convention refactor (BREAKING)
Replaced SoC-type-based library naming (`_dual_core`, `_single_core`, `_general`)
with role-based naming (`_peripheral`, `_central`, `_multirole`), selected via
a new `TL_BLE_CTRL_VARIANT` Kconfig choice:
- `TL_BLE_CTRL_PERIPHERAL`: Optimized for peripheral-only applications
- `TL_BLE_CTRL_CENTRAL`: Optimized for central-only applications
- `TL_BLE_CTRL_MULTIROLE`: Full-featured, auto-selected when advanced features
  (Ext Adv, Per Adv, ISO, Channel Sounding, 802.15.4 coexist) are enabled

#### Suspend exit latency optimization
- Removed per-SoC hardcoded `SUSPEND_EXIT_LATENCY_US` macros (previously 100µs–400µs)
- Exit latency is now dynamically managed by the BLE library at runtime via
  `blc_ll_get_suspend_exit_start_tick()` (called at suspend entry) and
  `blc_ll_set_suspend_exit_latency()` (called at resume)
- A conservative `1000µs` default is retained as fallback

## Breaking Changes
- BLE controller prebuilt library names have changed. Out-of-tree projects
  referencing the old names (`lib_zephyr_*_dual_core.a`, `lib_zephyr_*_single_core.a`,
  `lib_zephyr_*_general.a`) must update to the new naming scheme.
- `COMPILE_TL_LIB_GENERAL` Kconfig option removed; replaced by `TL_BLE_CTRL_VARIANT` choice.

## Testing
- Verified BLE peripheral/central/multirole configurations build and run on
  TL321X, TL322X, TL323X, TL521X, TL721X.
- Verified suspend/resume exit latency behavior with PM enabled.

Signed-off-by: Zhihan Tao <zhihan.tao@telink-semi.com>