### PR TITLE
docs: telink: update v1.4.0 release notes and README

### DIFF
--- a/README_cn.md
+++ b/README_cn.md
@@ -50,7 +50,7 @@ Telink Zephyr SDK 在保持与 Zephyr 生态兼容的基础上，增加了 Telin
 
 | 文档 | 说明 |
 | --- | --- |
-| [快速入门](doc/telink/getting_started/index.md) | 开发环境配置、SDK获取及快速上手方法 |
+| [快速入门](https://doc.telink-semi.cn/doc/zh/software/res/sdk/zephyr/get_started/telink_zephyr_sdk_get_started_cn/) | 开发环境配置、SDK获取及快速上手方法 |
 | [Telink Matter 开发手册](https://doc.telink-semi.cn/doc/zh/software/res/sdk/matter/telink_matter_developer_guide_cn/) | Telink Matter SDK 的软件架构、仓库结构及功能模块说明 |
 | [Release Notes](doc/telink/releases/release-notes.md) | 支持平台、版本说明及详细变化 |
 

--- a/README_cn.md
+++ b/README_cn.md
@@ -19,10 +19,12 @@ Telink Zephyr SDK (tl_zephyr) 是基于 Zephyr Project 构建的面向 Telink RI
 | 类别 | 能力说明 |
 | --- | --- |
 | 芯片平台支持 | Telink RISC-V SoC 支持、启动配置、内存及链接配置、开发板支持 |
+| 无线连接能力 | Telink BLE 协议栈、OpenThread 协议栈、BLE + Thread 并发模式（TL323X、TL721X） |
 | 硬件驱动支持 | 基于 Zephyr Driver Model 的 GPIO、UART、SPI、I²C、PWM、ADC、Timer、Flash 等外设支持 |
 | 软件框架支持 | Zephyr Kernel、Device Model、Driver Framework、Kconfig、West 构建系统 |
 | 系统服务 | 电源管理、日志系统、存储管理、系统配置 |
 | 安全能力 | MCUboot、安全启动、加密框架支持 |
+| 定位能力 | Bluetooth 6.0 Channel Sounding（CS）距离测量（TL721X） |
 | 生态支持 | 基于 Zephyr 生态支持 Bluetooth® LE、Thread、Matter 等应用开发 |
 | 示例支持 | Zephyr Samples 及 Telink reference examples |
 
@@ -33,6 +35,8 @@ Telink Zephyr SDK 在保持与 Zephyr 生态兼容的基础上，增加了 Telin
 - Bluetooth® LE 设备（HID、传感器、Beacon、可穿戴设备等）
 - Thread 智能家居设备（智能照明、传感器、控制设备等）
 - Matter 智能家居设备（灯具、插座、门锁、温控器等）
+- BLE + Thread 并发设备（同时运行 BLE 与 Thread 的网关/集线器设备，TL323X、TL721X）
+- 基于 Bluetooth 6.0 Channel Sounding（CS）的高精度定位/测距设备（TL721X）
 - 低功耗 IoT 终端设备（环境监测、资产管理、工业传感节点等）
 - 消费电子及复杂嵌入式设备（无线外设、智能控制器等）
 
@@ -46,9 +50,9 @@ Telink Zephyr SDK 在保持与 Zephyr 生态兼容的基础上，增加了 Telin
 
 | 文档 | 说明 |
 | --- | --- |
-| 快速入门 | 开发环境配置、SDK获取及快速上手方法 |
+| [快速入门](doc/telink/getting_started/index.md) | 开发环境配置、SDK获取及快速上手方法 |
 | [Telink Matter 开发手册](https://doc.telink-semi.cn/doc/zh/software/res/sdk/matter/telink_matter_developer_guide_cn/) | Telink Matter SDK 的软件架构、仓库结构及功能模块说明 |
-| Release Notes | 支持平台、版本说明及详细变化 |
+| [Release Notes](doc/telink/releases/release-notes.md) | 支持平台、版本说明及详细变化 |
 
 **社区与资源**
 

--- a/doc/telink/getting_started/index.md
+++ b/doc/telink/getting_started/index.md
@@ -233,7 +233,7 @@ chmod +x fetch_sdk.sh
 > arguments:
 >
 > ```bash
-> ./fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git 3bddf885c0a1e4342393b7c6b668ece104c12102
+> ./fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git de6f125c8ae6d29c4a640ab3526b40ff8c3f0a20
 > ```
 
 ### Switch branches or commits

--- a/doc/telink/releases/release-notes-tl_v1.4.0.md
+++ b/doc/telink/releases/release-notes-tl_v1.4.0.md
@@ -125,7 +125,7 @@ For the complete list, see the upstream [Zephyr v4.1.0 Release Notes — API Cha
 
 | Component                 | Repository                                                   | Commit                                                       | Notes                                                        |
 | ------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| **Telink BLE SDK**        | [telink-semi/tl\_ble\_sdk\_zephyr](https://github.com/telink-semi/tl_ble_sdk_zephyr) | [`3bddf88`](https://github.com/telink-semi/tl_ble_sdk_zephyr/commit/3bddf885c0a1e4342393b7c6b668ece104c12102) | Required by TL521X; fetch via `./hal_v2/fetch_sdk.sh` (hal\_v2) or `west blobs fetch hal_telink` (hal\_v1) |
+| **Telink BLE SDK**        | [telink-semi/tl\_ble\_sdk\_zephyr](https://github.com/telink-semi/tl_ble_sdk_zephyr) | [`de6f125`](https://github.com/telink-semi/tl_ble_sdk_zephyr/commit/de6f125c8ae6d29c4a640ab3526b40ff8c3f0a20) | Required by TL521X; fetch via `./hal_v2/fetch_sdk.sh` (hal\_v2) or `west blobs fetch hal_telink` (hal\_v1) |
 | **Telink HAL Zephyr**     | [telink-semi/hal\_telink](https://github.com/telink-semi/hal_telink) | [`bd870dc`](https://github.com/telink-semi/hal_telink/commit/bd870dc273989756f908077761a5e3adbd7d108f) | Contains both hal\_v1 and hal\_v2 sources                    |
 | **MCUBoot**               | [telink-semi/tl\_mcuboot](https://github.com/telink-semi/tl_mcuboot) | [`ce0da85`](https://github.com/telink-semi/tl_mcuboot/commit/ce0da85c39c749df49b0ec62b33d2ecdea24c927) | Bootloader; required for OTA/DFU                             |
 | **OpenThread Telink**     | [telink-semi/tl\_openthread](https://github.com/telink-semi/tl_openthread) | [`542aaab`](https://github.com/telink-semi/tl_openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee) | OpenThread source adapted for Telink                         |
@@ -162,7 +162,7 @@ The Telink OpenThread module for Zephyr, not a mirror of the offical OpenThread 
 ## 📌 Important Notes
 
 - Use `west update` to automatically pull `telink_ble_sdk` along with other modules.
-- Alternatively, manually fetch `telink_ble_sdk` by running `./hal_v2/fetch_sdk.sh {REPO_URL} {COMMIT_HASH}` inside `modules/hal/telink/` to pull or update the BLE stack to the version pinned by this release, where `{COMMIT_HASH}` is the `telink_ble_sdk` revision in `west.yml`. For this release, that is: `./hal_v2/fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git 3bddf885c0a1e4342393b7c6b668ece104c12102`
+- Alternatively, manually fetch `telink_ble_sdk` by running `./hal_v2/fetch_sdk.sh {REPO_URL} {COMMIT_HASH}` inside `modules/hal/telink/` to pull or update the BLE stack to the version pinned by this release, where `{COMMIT_HASH}` is the `telink_ble_sdk` revision in `west.yml`. For this release, that is: `./hal_v2/fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git de6f125c8ae6d29c4a640ab3526b40ff8c3f0a20`
 - For full environment setup instructions, refer to the [Telink Zephyr SDK Getting Started Guide](../getting_started/index.md) or the [Telink Matter Developer Guide](https://doc.telink-semi.cn/doc/en/software/res/sdk/matter/telink_matter_developer_guide_en/).
 
 ***

--- a/doc/telink/releases/release-notes-tl_v1.4.0.md
+++ b/doc/telink/releases/release-notes-tl_v1.4.0.md
@@ -1,13 +1,13 @@
 # Telink Zephyr SDK Release Note
 
-[![Version](https://img.shields.io/badge/Version-tl_v1.4.0--beta--v4.1.0-blue?style=flat-square)](https://github.com/telink-semi/tl_zephyr/releases/tag/tl_v1.4.0-beta-v4.1.0)
+[![Version](https://img.shields.io/badge/Version-tl_v1.4.0--v4.1.0-blue?style=flat-square)](https://github.com/telink-semi/tl_zephyr/releases/tag/tl_v1.4.0-v4.1.0)
 [![License](https://img.shields.io/badge/License-Apache%202.0-red?style=flat-square)](../../../LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v4.1.0-green?style=flat-square)](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v4.1.0)
 
 ***
 
 - **Release Type:** Public-Release
-- **Tag Version:** tl\_v1.4.0-beta-v4.1.0
+- **Tag Version:** tl\_v1.4.0-v4.1.0
 
 <!-- - **Branch:** dev-tlk_v4.1 -->
 <!-- - **Target Commit:** 0858e43f05a91d84ab2fed77f3849ff589510b24 -->
@@ -46,7 +46,7 @@ For environment setup, see the [Telink Zephyr SDK Getting Started Guide](../gett
 
 | Property         | Value                    |
 | ---------------- | ------------------------ |
-| **Tag Name**     | tl\_v1.4.0-beta-v4.1.0   |
+| **Tag Name**     | tl\_v1.4.0-v4.1.0        |
 | **Release Type** | Public-Release           |
 
 ### Chip & Hardware Versions

--- a/doc/telink/releases/release-notes-tl_v1.4.0.md
+++ b/doc/telink/releases/release-notes-tl_v1.4.0.md
@@ -143,6 +143,14 @@ The HAL module is pinned at tag `tl_v1.4.0-v4.0.4.8` (commit [`bd870dc`](https:/
 | Dynamic suspend-exit latency ([#205](https://github.com/telink-semi/hal_telink/pull/205)) | Remove the per-SoC hardcoded `SUSPEND_EXIT_LATENCY_US` macros from `tlx_bt_init.c`; the BLE library now records the suspend-exit start tick (`blc_ll_get_suspend_exit_start_tick`) for more accurate runtime latency handling |
 | Driver source sync ([#202](https://github.com/telink-semi/hal_telink/pull/202)) | Sync the hal_v2 wrapper with the latest Telink BLE SDK driver source changes (e.g. RF power control in `tl_rf_power.c`) |
 
+### Telink Zephyr OpenThread (tl_openthread) `tl_v1.4.0-v1.4`
+
+The Telink OpenThread module for Zephyr, not a mirror of the offical OpenThread repository. The OpenThread module is pinned at tag `tl_v1.4.0-v1.4` (commit [`542aaab`](https://github.com/telink-semi/tl_openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee)). For Zephyr 4.1, the corresponding OpenThread module is commit [`3ae741f`](https://github.com/telink-semi/tl_openthread/commit/3ae741f95e7dfb391dec35c48742862049eb62e8).Relative to the base version, this release tag includes the following changes:
+
+| Change | Description |
+| ------ | ----------- |
+| Add openthread sed code into ramcode ([#2](https://github.com/telink-semi/tl_openthread/pull/2)) | Put OpenThread SED proc call-tree into ramcode on chips with enough RAM (e.g., `TL721X`) to reduce wake‑up runtime and lower power consumption. This only applies when `CONFIG_PM` is enabled. |
+
 ***
 
 ## ⚠️ Known Issues and Limitations

--- a/doc/telink/releases/release-notes-tl_v1.4.0.md
+++ b/doc/telink/releases/release-notes-tl_v1.4.0.md
@@ -91,11 +91,11 @@ This release adds support for the new TL521X (TL5218X) chip series.
 
 | Issue | Component | Description |
 | ----- | --------- | ----------- |
-| #802  | Bluetooth | Fix Matter commissioning failure after the BLE to Thread switch |
-| #802  | Serial    | Fix a splitting issue found during the TL521X driver split |
-| #802  | MCUBoot   | Re-add `MCUBOOT_START_OFFSET` for B9X/W9X, which was lost during the shared TLX Kconfig move |
-| #832  | SoC       | Pull up the SWS pin after startup and retention reset |
-| #836  | SoC       | Reset the radio at boot to support switching from Zigbee to Matter |
+| [#802](https://github.com/telink-semi/tl_zephyr/pull/802) | Bluetooth | Fix Matter commissioning failure after the BLE to Thread switch |
+| [#802](https://github.com/telink-semi/tl_zephyr/pull/802) | Serial    | Fix a splitting issue found during the TL521X driver split |
+| [#802](https://github.com/telink-semi/tl_zephyr/pull/802) | MCUBoot   | Re-add `MCUBOOT_START_OFFSET` for B9X/W9X, which was lost during the shared TLX Kconfig move |
+| [#832](https://github.com/telink-semi/tl_zephyr/pull/832) | SoC       | Pull up the SWS pin after startup and retention reset |
+| [#836](https://github.com/telink-semi/tl_zephyr/pull/836) | SoC       | Reset the radio at boot to support switching from Zigbee to Matter |
 
 ***
 
@@ -107,11 +107,11 @@ The following Telink-specific Kconfig changes may affect existing applications w
 
 | Change | Impact | Migration |
 | ------ | ------ | --------- |
-| BLE controller library naming changed from SoC-based (`_dual_core`/`_single_core`/`_general`) to role-based (`_peripheral`/`_central`/`_multirole`), selected via the new `TL_BLE_CTRL_VARIANT` Kconfig choice (#830) | **BREAKING** — existing BLE applications must choose a role-based variant | Select the `TL_BLE_CTRL_VARIANT` value that matches the application role |
-| Removed the per-SoC hardcoded `SUSPEND_EXIT_LATENCY_US` macros; suspend-exit latency is now set dynamically by the BLE library at runtime (#830) | Applications relying on the removed macros break | Rely on the BLE library's runtime suspend-exit latency handling |
-| Restructured the SoC layout: TL321X/TL322X/TL323X/TL521X/TL721X/TL5X moved to the new `soc/telink/tlx/` family with dedicated Kconfig and linker scripts, and TL521X got independent drivers (#802) | Out-of-tree Kconfigs referencing the legacy family symbol may break | Update to the new SoC Kconfig symbols; a hidden `SOC_RISCV_TELINK_TLX` alias is kept for compatibility |
-| Changed the `tl5218x` board devicetree to the new `telink,tl521x-*` compatibles (#802) | Out-of-tree board dts/overlays using the old `telink,tlx-*` compatibles break | Update devicetree compatibles to `telink,tl521x-*` |
-| Added a TL521X retention Kconfig and scoped `HWINFO_TELINK_TLX` to TL321X/TL322X/TL323X/TL721X (#802) | TL521X now uses its own retention option; the tlx hwinfo driver is not built for TL521X | Select the TL521X retention option as needed; no change for TL321X/TL322X/TL323X/TL721X |
+| BLE controller library naming changed from SoC-based (`_dual_core`/`_single_core`/`_general`) to role-based (`_peripheral`/`_central`/`_multirole`), selected via the new `TL_BLE_CTRL_VARIANT` Kconfig choice ([#830](https://github.com/telink-semi/tl_zephyr/pull/830)) | **BREAKING** — existing BLE applications must choose a role-based variant | Select the `TL_BLE_CTRL_VARIANT` value that matches the application role |
+| Removed the per-SoC hardcoded `SUSPEND_EXIT_LATENCY_US` macros; suspend-exit latency is now set dynamically by the BLE library at runtime ([#830](https://github.com/telink-semi/tl_zephyr/pull/830)) | Applications relying on the removed macros break | Rely on the BLE library's runtime suspend-exit latency handling |
+| Restructured the SoC layout: TL321X/TL322X/TL323X/TL521X/TL721X/TL5X moved to the new `soc/telink/tlx/` family with dedicated Kconfig and linker scripts, and TL521X got independent drivers ([#802](https://github.com/telink-semi/tl_zephyr/pull/802)) | Out-of-tree Kconfigs referencing the legacy family symbol may break | Update to the new SoC Kconfig symbols; a hidden `SOC_RISCV_TELINK_TLX` alias is kept for compatibility |
+| Changed the `tl5218x` board devicetree to the new `telink,tl521x-*` compatibles ([#802](https://github.com/telink-semi/tl_zephyr/pull/802)) | Out-of-tree board dts/overlays using the old `telink,tlx-*` compatibles break | Update devicetree compatibles to `telink,tl521x-*` |
+| Added a TL521X retention Kconfig and scoped `HWINFO_TELINK_TLX` to TL321X/TL322X/TL323X/TL721X ([#802](https://github.com/telink-semi/tl_zephyr/pull/802)) | TL521X now uses its own retention option; the tlx hwinfo driver is not built for TL521X | Select the TL521X retention option as needed; no change for TL321X/TL322X/TL323X/TL721X |
 
 ### Upstream Inherited Changes
 
@@ -131,6 +131,17 @@ For the complete list, see the upstream [Zephyr v4.1.0 Release Notes — API Cha
 | **OpenThread Telink**     | [telink-semi/tl\_openthread](https://github.com/telink-semi/tl_openthread) | [`542aaab`](https://github.com/telink-semi/tl_openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee) | OpenThread source adapted for Telink                         |
 | **OpenThread Telink Lib** | [telink-semi/tl\_openthread\_libs](https://github.com/telink-semi/tl_openthread_libs) | [`f69c186`](https://github.com/telink-semi/tl_openthread_libs/commit/f69c186d65a41259480e87ccf9d2a7f665249778) | Pre-built OpenThread library for Telink                      |
 | **Telink XZ (LZMA)**      | [telink-semi/tl\_xz](https://github.com/telink-semi/tl_xz) | [`831f338`](https://github.com/telink-semi/tl_xz/commit/831f338fd6784661d3bec62fd01060ee4d7d373d) | LZMA compression library module (modules/lib/lzma)           |
+
+### Telink HAL Zephyr (hal\_telink) `tl_v1.4.0-v4.0.4.8`
+
+The HAL module is pinned at tag `tl_v1.4.0-v4.0.4.8` (commit [`bd870dc`](https://github.com/telink-semi/hal_telink/commit/bd870dc273989756f908077761a5e3adbd7d108f)). Compared with the previous release tag (`tl_v1.3.0-v4.0.4.8`), it includes the following changes:
+
+| Change | Description |
+| ------ | ----------- |
+| Support the new `tlx` SoC family ([#203](https://github.com/telink-semi/hal_telink/pull/203)) | Adapt the CMake build system for `CONFIG_SOC_FAMILY_TELINK_TLX`: `SOC_FAMILY` is set to `tlx` so the controller driver path resolves correctly; update the mbedtls ECP acceleration and IEEE802.15.4 include conditionals; keep the legacy TLX Kconfig symbols working for backward compatibility |
+| Role-based BLE controller library variants ([#205](https://github.com/telink-semi/hal_telink/pull/205)) | Replace the `COMPILE_TL_LIB_GENERAL` option with the `TL_BLE_CTRL_VARIANT` Kconfig choice (`TL_BLE_CTRL_PERIPHERAL` / `TL_BLE_CTRL_CENTRAL` / `TL_BLE_CTRL_MULTIROLE`), auto-selected from the BLE role configs; controller library names change from SoC-based (`_dual_core` / `_single_core` / `_general` / `_concurrent`) to role-based (`_peripheral` / `_central` / `_multirole`) |
+| Dynamic suspend-exit latency ([#205](https://github.com/telink-semi/hal_telink/pull/205)) | Remove the per-SoC hardcoded `SUSPEND_EXIT_LATENCY_US` macros from `tlx_bt_init.c`; the BLE library now records the suspend-exit start tick (`blc_ll_get_suspend_exit_start_tick`) for more accurate runtime latency handling |
+| Driver source sync ([#202](https://github.com/telink-semi/hal_telink/pull/202)) | Sync the hal_v2 wrapper with the latest Telink BLE SDK driver source changes (e.g. RF power control in `tl_rf_power.c`) |
 
 ***
 

--- a/doc/telink/releases/release-notes.md
+++ b/doc/telink/releases/release-notes.md
@@ -125,7 +125,7 @@ For the complete list, see the upstream [Zephyr v4.1.0 Release Notes — API Cha
 
 | Component                 | Repository                                                   | Commit                                                       | Notes                                                        |
 | ------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------ | ------------------------------------------------------------ |
-| **Telink BLE SDK**        | [telink-semi/tl\_ble\_sdk\_zephyr](https://github.com/telink-semi/tl_ble_sdk_zephyr) | [`3bddf88`](https://github.com/telink-semi/tl_ble_sdk_zephyr/commit/3bddf885c0a1e4342393b7c6b668ece104c12102) | Required by TL521X; fetch via `./hal_v2/fetch_sdk.sh` (hal\_v2) or `west blobs fetch hal_telink` (hal\_v1) |
+| **Telink BLE SDK**        | [telink-semi/tl\_ble\_sdk\_zephyr](https://github.com/telink-semi/tl_ble_sdk_zephyr) | [`de6f125`](https://github.com/telink-semi/tl_ble_sdk_zephyr/commit/de6f125c8ae6d29c4a640ab3526b40ff8c3f0a20) | Required by TL521X; fetch via `./hal_v2/fetch_sdk.sh` (hal\_v2) or `west blobs fetch hal_telink` (hal\_v1) |
 | **Telink HAL Zephyr**     | [telink-semi/hal\_telink](https://github.com/telink-semi/hal_telink) | [`bd870dc`](https://github.com/telink-semi/hal_telink/commit/bd870dc273989756f908077761a5e3adbd7d108f) | Contains both hal\_v1 and hal\_v2 sources                    |
 | **MCUBoot**               | [telink-semi/tl\_mcuboot](https://github.com/telink-semi/tl_mcuboot) | [`ce0da85`](https://github.com/telink-semi/tl_mcuboot/commit/ce0da85c39c749df49b0ec62b33d2ecdea24c927) | Bootloader; required for OTA/DFU                             |
 | **OpenThread Telink**     | [telink-semi/tl\_openthread](https://github.com/telink-semi/tl_openthread) | [`542aaab`](https://github.com/telink-semi/tl_openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee) | OpenThread source adapted for Telink                         |
@@ -162,7 +162,7 @@ The Telink OpenThread module for Zephyr, not a mirror of the offical OpenThread 
 ## 📌 Important Notes
 
 - Use `west update` to automatically pull `telink_ble_sdk` along with other modules.
-- Alternatively, manually fetch `telink_ble_sdk` by running `./hal_v2/fetch_sdk.sh {REPO_URL} {COMMIT_HASH}` inside `modules/hal/telink/` to pull or update the BLE stack to the version pinned by this release, where `{COMMIT_HASH}` is the `telink_ble_sdk` revision in `west.yml`. For this release, that is: `./hal_v2/fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git 3bddf885c0a1e4342393b7c6b668ece104c12102`
+- Alternatively, manually fetch `telink_ble_sdk` by running `./hal_v2/fetch_sdk.sh {REPO_URL} {COMMIT_HASH}` inside `modules/hal/telink/` to pull or update the BLE stack to the version pinned by this release, where `{COMMIT_HASH}` is the `telink_ble_sdk` revision in `west.yml`. For this release, that is: `./hal_v2/fetch_sdk.sh https://github.com/telink-semi/tl_ble_sdk_zephyr.git de6f125c8ae6d29c4a640ab3526b40ff8c3f0a20`
 - For full environment setup instructions, refer to the [Telink Zephyr SDK Getting Started Guide](../getting_started/index.md) or the [Telink Matter Developer Guide](https://doc.telink-semi.cn/doc/en/software/res/sdk/matter/telink_matter_developer_guide_en/).
 
 ***

--- a/doc/telink/releases/release-notes.md
+++ b/doc/telink/releases/release-notes.md
@@ -1,13 +1,13 @@
 # Telink Zephyr SDK Release Note
 
-[![Version](https://img.shields.io/badge/Version-tl_v1.4.0--beta--v4.1.0-blue?style=flat-square)](https://github.com/telink-semi/tl_zephyr/releases/tag/tl_v1.4.0-beta-v4.1.0)
+[![Version](https://img.shields.io/badge/Version-tl_v1.4.0--v4.1.0-blue?style=flat-square)](https://github.com/telink-semi/tl_zephyr/releases/tag/tl_v1.4.0-v4.1.0)
 [![License](https://img.shields.io/badge/License-Apache%202.0-red?style=flat-square)](../../../LICENSE)
 [![Zephyr](https://img.shields.io/badge/Zephyr-v4.1.0-green?style=flat-square)](https://github.com/zephyrproject-rtos/zephyr/releases/tag/v4.1.0)
 
 ***
 
 - **Release Type:** Public-Release
-- **Tag Version:** tl\_v1.4.0-beta-v4.1.0
+- **Tag Version:** tl\_v1.4.0-v4.1.0
 
 <!-- - **Branch:** dev-tlk_v4.1 -->
 <!-- - **Target Commit:** 0858e43f05a91d84ab2fed77f3849ff589510b24 -->
@@ -46,7 +46,7 @@ For environment setup, see the [Telink Zephyr SDK Getting Started Guide](../gett
 
 | Property         | Value                    |
 | ---------------- | ------------------------ |
-| **Tag Name**     | tl\_v1.4.0-beta-v4.1.0   |
+| **Tag Name**     | tl\_v1.4.0-v4.1.0        |
 | **Release Type** | Public-Release           |
 
 ### Chip & Hardware Versions

--- a/doc/telink/releases/release-notes.md
+++ b/doc/telink/releases/release-notes.md
@@ -143,6 +143,14 @@ The HAL module is pinned at tag `tl_v1.4.0-v4.0.4.8` (commit [`bd870dc`](https:/
 | Dynamic suspend-exit latency ([#205](https://github.com/telink-semi/hal_telink/pull/205)) | Remove the per-SoC hardcoded `SUSPEND_EXIT_LATENCY_US` macros from `tlx_bt_init.c`; the BLE library now records the suspend-exit start tick (`blc_ll_get_suspend_exit_start_tick`) for more accurate runtime latency handling |
 | Driver source sync ([#202](https://github.com/telink-semi/hal_telink/pull/202)) | Sync the hal_v2 wrapper with the latest Telink BLE SDK driver source changes (e.g. RF power control in `tl_rf_power.c`) |
 
+### Telink Zephyr OpenThread (tl_openthread) `tl_v1.4.0-v1.4`
+
+The Telink OpenThread module for Zephyr, not a mirror of the offical OpenThread repository. The OpenThread module is pinned at tag `tl_v1.4.0-v1.4` (commit [`542aaab`](https://github.com/telink-semi/tl_openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee)). For Zephyr 4.1, the corresponding OpenThread module is commit [`3ae741f`](https://github.com/telink-semi/tl_openthread/commit/3ae741f95e7dfb391dec35c48742862049eb62e8).Relative to the base version, this release tag includes the following changes:
+
+| Change | Description |
+| ------ | ----------- |
+| Add openthread sed code into ramcode ([#2](https://github.com/telink-semi/tl_openthread/pull/2)) | Put OpenThread SED proc call-tree into ramcode on chips with enough RAM (e.g., `TL721X`) to reduce wake‑up runtime and lower power consumption. This only applies when `CONFIG_PM` is enabled. |
+
 ***
 
 ## ⚠️ Known Issues and Limitations

--- a/doc/telink/releases/release-notes.md
+++ b/doc/telink/releases/release-notes.md
@@ -91,11 +91,11 @@ This release adds support for the new TL521X (TL5218X) chip series.
 
 | Issue | Component | Description |
 | ----- | --------- | ----------- |
-| #802  | Bluetooth | Fix Matter commissioning failure after the BLE to Thread switch |
-| #802  | Serial    | Fix a splitting issue found during the TL521X driver split |
-| #802  | MCUBoot   | Re-add `MCUBOOT_START_OFFSET` for B9X/W9X, which was lost during the shared TLX Kconfig move |
-| #832  | SoC       | Pull up the SWS pin after startup and retention reset |
-| #836  | SoC       | Reset the radio at boot to support switching from Zigbee to Matter |
+| [#802](https://github.com/telink-semi/tl_zephyr/pull/802) | Bluetooth | Fix Matter commissioning failure after the BLE to Thread switch |
+| [#802](https://github.com/telink-semi/tl_zephyr/pull/802) | Serial    | Fix a splitting issue found during the TL521X driver split |
+| [#802](https://github.com/telink-semi/tl_zephyr/pull/802) | MCUBoot   | Re-add `MCUBOOT_START_OFFSET` for B9X/W9X, which was lost during the shared TLX Kconfig move |
+| [#832](https://github.com/telink-semi/tl_zephyr/pull/832) | SoC       | Pull up the SWS pin after startup and retention reset |
+| [#836](https://github.com/telink-semi/tl_zephyr/pull/836) | SoC       | Reset the radio at boot to support switching from Zigbee to Matter |
 
 ***
 
@@ -107,11 +107,11 @@ The following Telink-specific Kconfig changes may affect existing applications w
 
 | Change | Impact | Migration |
 | ------ | ------ | --------- |
-| BLE controller library naming changed from SoC-based (`_dual_core`/`_single_core`/`_general`) to role-based (`_peripheral`/`_central`/`_multirole`), selected via the new `TL_BLE_CTRL_VARIANT` Kconfig choice (#830) | **BREAKING** — existing BLE applications must choose a role-based variant | Select the `TL_BLE_CTRL_VARIANT` value that matches the application role |
-| Removed the per-SoC hardcoded `SUSPEND_EXIT_LATENCY_US` macros; suspend-exit latency is now set dynamically by the BLE library at runtime (#830) | Applications relying on the removed macros break | Rely on the BLE library's runtime suspend-exit latency handling |
-| Restructured the SoC layout: TL321X/TL322X/TL323X/TL521X/TL721X/TL5X moved to the new `soc/telink/tlx/` family with dedicated Kconfig and linker scripts, and TL521X got independent drivers (#802) | Out-of-tree Kconfigs referencing the legacy family symbol may break | Update to the new SoC Kconfig symbols; a hidden `SOC_RISCV_TELINK_TLX` alias is kept for compatibility |
-| Changed the `tl5218x` board devicetree to the new `telink,tl521x-*` compatibles (#802) | Out-of-tree board dts/overlays using the old `telink,tlx-*` compatibles break | Update devicetree compatibles to `telink,tl521x-*` |
-| Added a TL521X retention Kconfig and scoped `HWINFO_TELINK_TLX` to TL321X/TL322X/TL323X/TL721X (#802) | TL521X now uses its own retention option; the tlx hwinfo driver is not built for TL521X | Select the TL521X retention option as needed; no change for TL321X/TL322X/TL323X/TL721X |
+| BLE controller library naming changed from SoC-based (`_dual_core`/`_single_core`/`_general`) to role-based (`_peripheral`/`_central`/`_multirole`), selected via the new `TL_BLE_CTRL_VARIANT` Kconfig choice ([#830](https://github.com/telink-semi/tl_zephyr/pull/830)) | **BREAKING** — existing BLE applications must choose a role-based variant | Select the `TL_BLE_CTRL_VARIANT` value that matches the application role |
+| Removed the per-SoC hardcoded `SUSPEND_EXIT_LATENCY_US` macros; suspend-exit latency is now set dynamically by the BLE library at runtime ([#830](https://github.com/telink-semi/tl_zephyr/pull/830)) | Applications relying on the removed macros break | Rely on the BLE library's runtime suspend-exit latency handling |
+| Restructured the SoC layout: TL321X/TL322X/TL323X/TL521X/TL721X/TL5X moved to the new `soc/telink/tlx/` family with dedicated Kconfig and linker scripts, and TL521X got independent drivers ([#802](https://github.com/telink-semi/tl_zephyr/pull/802)) | Out-of-tree Kconfigs referencing the legacy family symbol may break | Update to the new SoC Kconfig symbols; a hidden `SOC_RISCV_TELINK_TLX` alias is kept for compatibility |
+| Changed the `tl5218x` board devicetree to the new `telink,tl521x-*` compatibles ([#802](https://github.com/telink-semi/tl_zephyr/pull/802)) | Out-of-tree board dts/overlays using the old `telink,tlx-*` compatibles break | Update devicetree compatibles to `telink,tl521x-*` |
+| Added a TL521X retention Kconfig and scoped `HWINFO_TELINK_TLX` to TL321X/TL322X/TL323X/TL721X ([#802](https://github.com/telink-semi/tl_zephyr/pull/802)) | TL521X now uses its own retention option; the tlx hwinfo driver is not built for TL521X | Select the TL521X retention option as needed; no change for TL321X/TL322X/TL323X/TL721X |
 
 ### Upstream Inherited Changes
 
@@ -131,6 +131,17 @@ For the complete list, see the upstream [Zephyr v4.1.0 Release Notes — API Cha
 | **OpenThread Telink**     | [telink-semi/tl\_openthread](https://github.com/telink-semi/tl_openthread) | [`542aaab`](https://github.com/telink-semi/tl_openthread/commit/542aaab44e1308e1a8a24573dfbd413fade342ee) | OpenThread source adapted for Telink                         |
 | **OpenThread Telink Lib** | [telink-semi/tl\_openthread\_libs](https://github.com/telink-semi/tl_openthread_libs) | [`f69c186`](https://github.com/telink-semi/tl_openthread_libs/commit/f69c186d65a41259480e87ccf9d2a7f665249778) | Pre-built OpenThread library for Telink                      |
 | **Telink XZ (LZMA)**      | [telink-semi/tl\_xz](https://github.com/telink-semi/tl_xz) | [`831f338`](https://github.com/telink-semi/tl_xz/commit/831f338fd6784661d3bec62fd01060ee4d7d373d) | LZMA compression library module (modules/lib/lzma)           |
+
+### Telink HAL Zephyr (hal\_telink) `tl_v1.4.0-v4.0.4.8`
+
+The HAL module is pinned at tag `tl_v1.4.0-v4.0.4.8` (commit [`bd870dc`](https://github.com/telink-semi/hal_telink/commit/bd870dc273989756f908077761a5e3adbd7d108f)). Compared with the previous release tag (`tl_v1.3.0-v4.0.4.8`), it includes the following changes:
+
+| Change | Description |
+| ------ | ----------- |
+| Support the new `tlx` SoC family ([#203](https://github.com/telink-semi/hal_telink/pull/203)) | Adapt the CMake build system for `CONFIG_SOC_FAMILY_TELINK_TLX`: `SOC_FAMILY` is set to `tlx` so the controller driver path resolves correctly; update the mbedtls ECP acceleration and IEEE802.15.4 include conditionals; keep the legacy TLX Kconfig symbols working for backward compatibility |
+| Role-based BLE controller library variants ([#205](https://github.com/telink-semi/hal_telink/pull/205)) | Replace the `COMPILE_TL_LIB_GENERAL` option with the `TL_BLE_CTRL_VARIANT` Kconfig choice (`TL_BLE_CTRL_PERIPHERAL` / `TL_BLE_CTRL_CENTRAL` / `TL_BLE_CTRL_MULTIROLE`), auto-selected from the BLE role configs; controller library names change from SoC-based (`_dual_core` / `_single_core` / `_general` / `_concurrent`) to role-based (`_peripheral` / `_central` / `_multirole`) |
+| Dynamic suspend-exit latency ([#205](https://github.com/telink-semi/hal_telink/pull/205)) | Remove the per-SoC hardcoded `SUSPEND_EXIT_LATENCY_US` macros from `tlx_bt_init.c`; the BLE library now records the suspend-exit start tick (`blc_ll_get_suspend_exit_start_tick`) for more accurate runtime latency handling |
+| Driver source sync ([#202](https://github.com/telink-semi/hal_telink/pull/202)) | Sync the hal_v2 wrapper with the latest Telink BLE SDK driver source changes (e.g. RF power control in `tl_rf_power.c`) |
 
 ***
 

--- a/west.yml
+++ b/west.yml
@@ -370,7 +370,7 @@ manifest:
     - name: telink_ble_sdk
       remote: telink-semi
       repo-path: tl_ble_sdk_zephyr
-      revision: 3bddf885c0a1e4342393b7c6b668ece104c12102
+      revision: de6f125c8ae6d29c4a640ab3526b40ff8c3f0a20
       path: modules/hal/telink_ble_sdk
       groups:
         - hal


### PR DESCRIPTION
Update the Telink Zephyr SDK v1.4.0 documentation for the official
tl_v1.4.0-v4.1.0 release:

- Document hal_telink tl_v1.4.0-v4.0.4.8 changes: new tlx SoC family
  support (#203), role-based BLE controller library variants and dynamic
  suspend-exit latency (#205), and driver source sync (#202); add
  hyperlinks to PR references in the Bug Fixes and API & Kconfig tables.
- Add Telink Zephyr OpenThread release information to the release notes.
- Switch the version badge and tag from tl_v1.4.0-beta-v4.1.0 to the
  official tl_v1.4.0-v4.1.0.
- Update the Chinese README with wireless connectivity and positioning
  capabilities (BLE stack, OpenThread, BLE + Thread concurrent, Channel
  Sounding) and documentation links.
- Bump the tl_ble_sdk_zephyr revision to de6f125c (doc-only release
  notes update).
- Point the Chinese README quick-start link to the online Chinese
  getting-started guide.