### PR TITLE
ci: extend backport workflow

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -8,6 +8,8 @@ on:
       - main
       - develop
       - dev-tlk_v*
+      - release-v*
+      - pre_release-v*
 
 jobs:
   backport:


### PR DESCRIPTION
Add release-v*/pre_release-v* to the backport trigger
branches so a PR merged into a release branch (e.g.
release-v1.4-v4.1-branch) can be backported to an
older release branch via the `backport <branch>` label.